### PR TITLE
Fix Constructor signature to use argument appropriately.

### DIFF
--- a/utilities/ride-model-util/src/main/java/com/adobe/ride/utilities/model/ModelObject.java
+++ b/utilities/ride-model-util/src/main/java/com/adobe/ride/utilities/model/ModelObject.java
@@ -253,7 +253,7 @@ public class ModelObject {
    */
   public ModelObject(String resourceLocation, JSONObject presetNodes, Set<String> nodesToBuild,
       boolean useRequiredOnly) {
-    initializeModelObject(resourceLocation, presetNodes, nodesToBuild, true);
+    initializeModelObject(resourceLocation, presetNodes, nodesToBuild, useRequiredOnly);
   }
 
   private void initializeModelObject(String resourceLocation, JSONObject presetNodes,


### PR DESCRIPTION
Fix big in one of the ModelObject constructors

## Description
In one of the constructors, one of the arguments was overridden.  This change now makes ModelObject honor that argument.

## Related Issue

N/A

## Motivation and Context

Bug

## How Has This Been Tested?

Locally

## Screenshots (if appropriate):

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:



- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
