### PR TITLE
Generating example data for Primitive Schema and enhanced support for data-type formats

### DIFF
--- a/utilities/ride-model-util/src/main/java/com/adobe/ride/utilities/model/ModelObject.java
+++ b/utilities/ride-model-util/src/main/java/com/adobe/ride/utilities/model/ModelObject.java
@@ -525,6 +525,7 @@ public class ModelObject {
       }
       return objectItems;
     } else {
+    	// Handling Primitive type schemas
     	return generateNodeValue(model);
     }
   }

--- a/utilities/ride-model-util/src/main/java/com/adobe/ride/utilities/model/ModelObject.java
+++ b/utilities/ride-model-util/src/main/java/com/adobe/ride/utilities/model/ModelObject.java
@@ -98,9 +98,9 @@ public class ModelObject {
         requiredModelProperties = (JSONArray) model.get("required");
         modelDefinitions = (JSONObject) model.get("definitions");
         try {
-        	modelPropertiesNodes = mapper.readTree(modelProperties.toJSONString());
+          modelPropertiesNodes = mapper.readTree(modelProperties.toJSONString());
         } catch (IOException e) {
-        	logger.log(Level.SEVERE, "An error was thrown while deserializing the JSON content", e);
+          logger.log(Level.SEVERE, "An error was thrown while deserializing the JSON content", e);
         }
       } else if (modelType == ModelPropertyType.ARRAY) {
         JSONObject arrayDef = ((JSONObject) model.get("items"));
@@ -108,9 +108,9 @@ public class ModelObject {
         requiredModelProperties = (JSONArray) arrayDef.get("required");
         modelDefinitions = (JSONObject) model.get("definitions");
         try {
-        	modelPropertiesNodes = mapper.readTree(modelProperties.toJSONString());
+          modelPropertiesNodes = mapper.readTree(modelProperties.toJSONString());
         } catch (IOException e) {
-        	logger.log(Level.SEVERE, "An error was thrown while deserializing the JSON content", e);
+          logger.log(Level.SEVERE, "An error was thrown while deserializing the JSON content", e);
         }
       }
     } catch (ParseException e) {
@@ -441,15 +441,15 @@ public class ModelObject {
         returnValue = ModelPropertyType.URI;
       } else if (format.equals("uri-reference")) {
         returnValue = ModelPropertyType.URI_REF;
-      } 
+      }
     } else if (object.containsKey("pattern")) {
       returnValue = ModelPropertyType.PATTERN;
-    } 
-    	
-    if (returnValue == null && !"noType".equals(type)) {
-    	returnValue = ModelPropertyType.eval(type);
     }
-    
+
+    if (returnValue == null && !"noType".equals(type)) {
+      returnValue = ModelPropertyType.eval(type);
+    }
+
     if (returnValue == null) {
       throw new UnexpectedModelPropertyTypeException(object);
     }
@@ -525,8 +525,8 @@ public class ModelObject {
       }
       return objectItems;
     } else {
-    	// Handling Primitive type schemas
-    	return generateNodeValue(model);
+      // Handling Primitive type schemas
+      return generateNodeValue(model);
     }
   }
 
@@ -1123,7 +1123,7 @@ public class ModelObject {
     try {
       return generateNodeValue(null, null, propertyDef);
     } catch (ModelSearchException e) {
-    	logger.log(Level.SEVERE, e.getMessage());
+      logger.log(Level.SEVERE, e.getMessage());
     }
     return null;
   }

--- a/utilities/ride-model-util/src/test/java/com/adobe/ride/utilities/model/test/ModelObjectTest.java
+++ b/utilities/ride-model-util/src/test/java/com/adobe/ride/utilities/model/test/ModelObjectTest.java
@@ -26,6 +26,8 @@ import org.testng.annotations.Test;
 
 import com.adobe.ride.utilities.model.ModelObject;
 import com.adobe.ride.utilities.model.exceptions.ModelSearchException;
+import com.adobe.ride.utilities.model.exceptions.UnexpectedModelPropertyTypeException;
+import com.adobe.ride.utilities.model.types.ModelPropertyType;
 
 /**
  * 
@@ -206,6 +208,27 @@ public class ModelObjectTest {
     JSONArray objects = testObj.generateModelInstances(10);
     ModelObject.prettyPrintToConsole(objects);
   }
+  
+	@Test(suiteName = "smoke", groups = "integration", enabled = true)
+	public void testPrimitiveSchemaDefinitionModelInstance() {
+		final String schema = "{\"type\":\"integer\", \"format\":\"int32\"}";
+		final ModelObject modelObject = new ModelObject(schema, false);
+		final Object modelInstance = modelObject.buildValidModelInstance();
+		Assert.assertNotNull(modelInstance);
+	}
+
+	@Test(suiteName = "smoke", groups = "integration", enabled = true)
+	public void testFallBackToSchemaTypeIfFormatCannotBeIdentified() throws UnexpectedModelPropertyTypeException {
+		String schema = "{\"type\":\"integer\", \"format\":\"int32\"}";
+		ModelObject modelObject = new ModelObject(schema, false);
+		JSONObject model = modelObject.getModel();
+		Assert.assertEquals(ModelObject.getModelPropertyType(model), ModelPropertyType.INTEGER);
+
+		schema = "{\"type\":\"string\", \"format\":\"binary\"}";
+		modelObject = new ModelObject(schema, false);
+		model = modelObject.getModel();
+		Assert.assertEquals(ModelObject.getModelPropertyType(model), ModelPropertyType.STRING);
+	}
 
   // TODO: Implement this test
   /*-

--- a/utilities/ride-model-util/src/test/java/com/adobe/ride/utilities/model/test/ModelObjectTest.java
+++ b/utilities/ride-model-util/src/test/java/com/adobe/ride/utilities/model/test/ModelObjectTest.java
@@ -214,7 +214,7 @@ public class ModelObjectTest {
 		final String schema = "{\"type\":\"integer\", \"format\":\"int32\"}";
 		final ModelObject modelObject = new ModelObject(schema, false);
 		final Object modelInstance = modelObject.buildValidModelInstance();
-		Assert.assertNotNull(modelInstance);
+		Assert.assertTrue(modelInstance instanceof Long);
 	}
 
 	@Test(suiteName = "smoke", groups = "integration", enabled = true)

--- a/utilities/ride-model-util/src/test/java/com/adobe/ride/utilities/model/test/ModelObjectTest.java
+++ b/utilities/ride-model-util/src/test/java/com/adobe/ride/utilities/model/test/ModelObjectTest.java
@@ -17,13 +17,11 @@ import java.io.InputStream;
 import java.nio.charset.Charset;
 import java.util.HashSet;
 import java.util.Set;
-
 import org.apache.commons.io.IOUtils;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.testng.Assert;
 import org.testng.annotations.Test;
-
 import com.adobe.ride.utilities.model.ModelObject;
 import com.adobe.ride.utilities.model.exceptions.ModelSearchException;
 import com.adobe.ride.utilities.model.exceptions.UnexpectedModelPropertyTypeException;
@@ -208,27 +206,28 @@ public class ModelObjectTest {
     JSONArray objects = testObj.generateModelInstances(10);
     ModelObject.prettyPrintToConsole(objects);
   }
-  
-	@Test(suiteName = "smoke", groups = "integration", enabled = true)
-	public void testPrimitiveSchemaDefinitionModelInstance() {
-		final String schema = "{\"type\":\"integer\", \"format\":\"int32\"}";
-		final ModelObject modelObject = new ModelObject(schema, false);
-		final Object modelInstance = modelObject.buildValidModelInstance();
-		Assert.assertTrue(modelInstance instanceof Long);
-	}
 
-	@Test(suiteName = "smoke", groups = "integration", enabled = true)
-	public void testFallBackToSchemaTypeIfFormatCannotBeIdentified() throws UnexpectedModelPropertyTypeException {
-		String schema = "{\"type\":\"integer\", \"format\":\"int32\"}";
-		ModelObject modelObject = new ModelObject(schema, false);
-		JSONObject model = modelObject.getModel();
-		Assert.assertEquals(ModelObject.getModelPropertyType(model), ModelPropertyType.INTEGER);
+  @Test(suiteName = "smoke", groups = "integration", enabled = true)
+  public void testPrimitiveSchemaDefinitionModelInstance() {
+    final String schema = "{\"type\":\"integer\", \"format\":\"int32\"}";
+    final ModelObject modelObject = new ModelObject(schema, false);
+    final Object modelInstance = modelObject.buildValidModelInstance();
+    Assert.assertTrue(modelInstance instanceof Long);
+  }
 
-		schema = "{\"type\":\"string\", \"format\":\"binary\"}";
-		modelObject = new ModelObject(schema, false);
-		model = modelObject.getModel();
-		Assert.assertEquals(ModelObject.getModelPropertyType(model), ModelPropertyType.STRING);
-	}
+  @Test(suiteName = "smoke", groups = "integration", enabled = true)
+  public void testFallBackToSchemaTypeIfFormatCannotBeIdentified()
+      throws UnexpectedModelPropertyTypeException {
+    String schema = "{\"type\":\"integer\", \"format\":\"int32\"}";
+    ModelObject modelObject = new ModelObject(schema, false);
+    JSONObject model = modelObject.getModel();
+    Assert.assertEquals(ModelObject.getModelPropertyType(model), ModelPropertyType.INTEGER);
+
+    schema = "{\"type\":\"string\", \"format\":\"binary\"}";
+    modelObject = new ModelObject(schema, false);
+    model = modelObject.getModel();
+    Assert.assertEquals(ModelObject.getModelPropertyType(model), ModelPropertyType.STRING);
+  }
 
   // TODO: Implement this test
   /*-


### PR DESCRIPTION
## Description

The ModelObject source has been updated to - 1) Identify Primitive type schemas and 2) Fall back to the "type" property if a correct format cannot be identified or is not specified.

## Related Issue

https://github.com/adobe/ride/issues/25
https://github.com/adobe/ride/issues/24

## How Has This Been Tested?

Added following unit-tests to ModelObjectTest - testPrimitiveSchemaDefinitionModelInstance() and testFallBackToSchemaTypeIfFormatCannotBeIdentified()

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
