### PR TITLE
Issue #27 and Issue #29 - uri format doesn't include protocol

### DIFF
--- a/utilities/ride-model-util/src/main/java/com/adobe/ride/utilities/model/DataGenerator.java
+++ b/utilities/ride-model-util/src/main/java/com/adobe/ride/utilities/model/DataGenerator.java
@@ -38,6 +38,8 @@ import org.apache.commons.lang.RandomStringUtils;
 import org.apache.commons.lang.time.DateUtils;
 import org.json.simple.JSONArray;
 import org.json.simple.parser.JSONParser;
+
+import com.google.common.net.InetAddresses;
 import com.mifmif.common.regex.Generex;
 
 /**
@@ -158,8 +160,7 @@ public abstract class DataGenerator {
    * @return String
    */
   public static String generateIPv4() {
-    return generateRegexValue(IPV4_REGEX);
-    // "25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]");
+    return InetAddresses.fromInteger(randomGen.nextInt()).getHostAddress();
   }
 
   /**

--- a/utilities/ride-model-util/src/main/java/com/adobe/ride/utilities/model/ModelObject.java
+++ b/utilities/ride-model-util/src/main/java/com/adobe/ride/utilities/model/ModelObject.java
@@ -1339,7 +1339,7 @@ public class ModelObject {
           returnValue = alphaNum;
           break;
         case URI:
-          String uri = DataGenerator.generateURI();
+          String uri = DataGenerator.generateRandomURIRef();
           returnValue = uri;
           break;
         case URI_REF:


### PR DESCRIPTION
## Description

Update data generated for uri format to match standard

## Related Issue

Issue #27 
Issue #29 

## Motivation and Context

Generated json with schema's that contain format=uri are failing validation due to invalid uri format.
Same for ipv4

## How Has This Been Tested?

I tested this on a schema with multiple uri's and validation passed for all of them.  For ipv4 I generated a large amount of addresses and then validated them all using https://www.regextester.com/95309

## Screenshots (if appropriate):

## Types of changes

- [ X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
