### PR TITLE
[Issue #52] Add schema content + presetNodes ModelObject constructor

### DIFF
--- a/utilities/ride-model-util/src/main/java/com/adobe/ride/utilities/model/ModelObject.java
+++ b/utilities/ride-model-util/src/main/java/com/adobe/ride/utilities/model/ModelObject.java
@@ -294,12 +294,6 @@ public class ModelObject {
    */
   public ModelObject(String resourceLocation, String modelString, JSONObject presetNodes,
       Set<String> nodesToBuild, boolean useRequiredOnly) {
-    initializeModelObject(resourceLocation, modelString, presetNodes, nodesToBuild,
-        useRequiredOnly);
-  }
-
-  private void initializeModelObject(String resourceLocation, String modelString,
-      JSONObject presetNodes, Set<String> nodesToBuild, boolean useRequiredOnly) {
     if (presetNodes != null) {
       this.presetNodes = presetNodes;
     }

--- a/utilities/ride-model-util/src/main/java/com/adobe/ride/utilities/model/ModelObject.java
+++ b/utilities/ride-model-util/src/main/java/com/adobe/ride/utilities/model/ModelObject.java
@@ -291,22 +291,22 @@ public class ModelObject {
    *        defined nodes will not be generated.
    * @param useRequiredOnly boolean to determine whether to build only the required json nodes as
    *        defined in the spec
+   *
+   * @return ModelObject the model object
    */
-  public ModelObject(String resourceLocation, String modelString, JSONObject presetNodes,
+  public static ModelObject createFromSchemaString(String modelString, JSONObject presetNodes,
       Set<String> nodesToBuild, boolean useRequiredOnly) {
+    ModelObject modelObject = new ModelObject(modelString, useRequiredOnly);
+
     if (presetNodes != null) {
-      this.presetNodes = presetNodes;
+      modelObject.presetNodes = presetNodes;
     }
 
     if (nodesToBuild != null) {
-      this.nodesToBuild = nodesToBuild;
+      modelObject.nodesToBuild = nodesToBuild;
     }
 
-    this.requiredOnly = useRequiredOnly;
-
-    this.resourceLocation = resourceLocation;
-    this.modelString = modelString;
-    loadModelString(modelString);
+    return modelObject;
   }
 
   /**

--- a/utilities/ride-model-util/src/main/java/com/adobe/ride/utilities/model/ModelObject.java
+++ b/utilities/ride-model-util/src/main/java/com/adobe/ride/utilities/model/ModelObject.java
@@ -279,16 +279,14 @@ public class ModelObject {
   }
 
   /**
-   * Create a model object from a json schema string and use a predefined set of nodes to start
-   * with. Also only build a targeted set of nodes. The specified resource location is only used as
-   * metadata, so the content will not be fetched from it.
-   * 
-   * @param resourceLocation location of the schema within the project resources.
+	 * Static constructor to initialize with a JSON schema string. Optional parameters for
+	 * adding preset nodes, defining target nodes, and whether to use only required
+	 * nodes.
    * @param modelString string which conforms to JSON schema standards
-   * @param presetNodes set of JSON nodes and values to be used in the object, not generated
-   *        dynamically
-   * @param nodesToBuild set of JSONnodes which are to be dynamically generated. Remaining schema
-   *        defined nodes will not be generated.
+   * @param presetNodes optional set of JSON nodes and values to be used in the object, not
+   *        generated dynamically
+   * @param nodesToBuild optional set of JSONnodes which are to be dynamically generated.
+   *        Remaining schema defined nodes will not be generated.
    * @param useRequiredOnly boolean to determine whether to build only the required json nodes as
    *        defined in the spec
    *

--- a/utilities/ride-model-util/src/main/java/com/adobe/ride/utilities/model/ModelObject.java
+++ b/utilities/ride-model-util/src/main/java/com/adobe/ride/utilities/model/ModelObject.java
@@ -279,6 +279,43 @@ public class ModelObject {
   }
 
   /**
+   * Create a model object from a json schema string and use a predefined set of nodes to start
+   * with. Also only build a targeted set of nodes. The specified resource location is only used as
+   * metadata, so the content will not be fetched from it.
+   * 
+   * @param resourceLocation location of the schema within the project resources.
+   * @param modelString string which conforms to JSON schema standards
+   * @param presetNodes set of JSON nodes and values to be used in the object, not generated
+   *        dynamically
+   * @param nodesToBuild set of JSONnodes which are to be dynamically generated. Remaining schema
+   *        defined nodes will not be generated.
+   * @param useRequiredOnly boolean to determine whether to build only the required json nodes as
+   *        defined in the spec
+   */
+  public ModelObject(String resourceLocation, String modelString, JSONObject presetNodes,
+      Set<String> nodesToBuild, boolean useRequiredOnly) {
+    initializeModelObject(resourceLocation, modelString, presetNodes, nodesToBuild,
+        useRequiredOnly);
+  }
+
+  private void initializeModelObject(String resourceLocation, String modelString,
+      JSONObject presetNodes, Set<String> nodesToBuild, boolean useRequiredOnly) {
+    if (presetNodes != null) {
+      this.presetNodes = presetNodes;
+    }
+
+    if (nodesToBuild != null) {
+      this.nodesToBuild = nodesToBuild;
+    }
+
+    this.requiredOnly = useRequiredOnly;
+
+    this.resourceLocation = resourceLocation;
+    this.modelString = modelString;
+    loadModelString(modelString);
+  }
+
+  /**
    * Constructor to initialize with a JSON schema string
    * 
    * @param modelString string which conforms to JSON schema standards

--- a/utilities/ride-model-util/src/test/java/com/adobe/ride/utilities/model/test/ModelObjectTest.java
+++ b/utilities/ride-model-util/src/test/java/com/adobe/ride/utilities/model/test/ModelObjectTest.java
@@ -89,7 +89,7 @@ public class ModelObjectTest {
     // pull in model as String
     try {
       InputStream inputStream =
-          ModelObject.class.getResourceAsStream("/schemas/TestService/simple.json");
+          ClassLoader.class.getResourceAsStream("/schemas/TestService/simple.json");
       Charset nullCharset = null; // platform default
       modelString = IOUtils.toString(inputStream, nullCharset);
     } catch (IOException e) {
@@ -113,7 +113,7 @@ public class ModelObjectTest {
     String modelString = "";
     try {
       InputStream inputStream =
-          ModelObject.class.getResourceAsStream("/schemas/TestService/simple.json");
+          ClassLoader.class.getResourceAsStream("/schemas/TestService/simple.json");
       Charset nullCharset = null; // platform default
       modelString = IOUtils.toString(inputStream, nullCharset);
     } catch (IOException e) {

--- a/utilities/ride-model-util/src/test/java/com/adobe/ride/utilities/model/test/ModelObjectTest.java
+++ b/utilities/ride-model-util/src/test/java/com/adobe/ride/utilities/model/test/ModelObjectTest.java
@@ -89,7 +89,7 @@ public class ModelObjectTest {
     // pull in model as String
     try {
       InputStream inputStream =
-          ClassLoader.class.getResourceAsStream("/schemas/TestService/simple.json");
+          ModelObject.class.getResourceAsStream("/schemas/TestService/simple.json");
       Charset nullCharset = null; // platform default
       modelString = IOUtils.toString(inputStream, nullCharset);
     } catch (IOException e) {

--- a/utilities/ride-model-util/src/test/java/com/adobe/ride/utilities/model/test/ModelObjectTest.java
+++ b/utilities/ride-model-util/src/test/java/com/adobe/ride/utilities/model/test/ModelObjectTest.java
@@ -113,7 +113,7 @@ public class ModelObjectTest {
     String modelString = "";
     try {
       InputStream inputStream =
-          ClassLoader.class.getResourceAsStream("/schemas/TestService/simple.json");
+          ClassLoader.class.getResourceAsStream("/schemas/TestService/entitylink.json");
       Charset nullCharset = null; // platform default
       modelString = IOUtils.toString(inputStream, nullCharset);
     } catch (IOException e) {
@@ -122,19 +122,20 @@ public class ModelObjectTest {
 
     // Presets
     JSONObject presets = new JSONObject();
-    JSONObject title = new JSONObject();
-    title.put("title", "Gladys Phillips");
-    presets.put("title", title);
+    JSONObject href = new JSONObject();
+    href.put("href", "ftp://test.com/data/file.txt");
+    presets.put("href", href);
 
     // Targets
     Set<String> targetNodes = new HashSet<String>();
-    targetNodes.add("/title");
+    targetNodes.add("/href");
+    targetNodes.add("/type");
 
     // Instantiate
     ModelObject responseObj =
         ModelObject.createFromSchemaString(modelString, presets, targetNodes, true);
     JSONObject model = responseObj.getModel();
-    Assert.assertTrue(model.containsKey("title"));
+    Assert.assertTrue(model.containsKey("properties"));
 
     // Gen data
     responseObj.buildValidModelInstance();
@@ -143,7 +144,8 @@ public class ModelObjectTest {
     ModelObject.prettyPrintToConsole(responseObj.getObjectMetadata());
 
     Set<String> test = responseObj.getObjectMetadata().keySet();
-    Assert.assertTrue(test.contains("title"));
+    Assert.assertTrue(test.contains("href"));
+    Assert.assertTrue(test.contains("type"));
   }
 
   @SuppressWarnings("unchecked")

--- a/utilities/ride-model-util/src/test/java/com/adobe/ride/utilities/model/test/ModelObjectTest.java
+++ b/utilities/ride-model-util/src/test/java/com/adobe/ride/utilities/model/test/ModelObjectTest.java
@@ -108,6 +108,46 @@ public class ModelObjectTest {
 
   @SuppressWarnings("unchecked")
   @Test(suiteName = "smoke", groups = "integration", enabled = true)
+  public void testSchemaStringStatic() throws ModelSearchException {
+    // Model String
+    String modelString = "";
+    try {
+      InputStream inputStream =
+          ModelObject.class.getResourceAsStream("/schemas/TestService/simple.json");
+      Charset nullCharset = null; // platform default
+      modelString = IOUtils.toString(inputStream, nullCharset);
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
+
+    // Presets
+    JSONObject presets = new JSONObject();
+    JSONObject title = new JSONObject();
+    title.put("title", "Gladys Phillips");
+    presets.put("title", title);
+
+    // Targets
+    Set<String> targetNodes = new HashSet<String>();
+    targetNodes.add("/title");
+
+    // Instantiate
+    ModelObject responseObj =
+        ModelObject.createFromSchemaString(modelString, presets, targetNodes, true);
+    JSONObject model = responseObj.getModel();
+    Assert.assertTrue(model.containsKey("title"));
+
+    // Gen data
+    responseObj.buildValidModelInstance();
+
+    // Dump To Console
+    ModelObject.prettyPrintToConsole(responseObj.getObjectMetadata());
+
+    Set<String> test = responseObj.getObjectMetadata().keySet();
+    Assert.assertTrue(test.contains("title"));
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test(suiteName = "smoke", groups = "integration", enabled = true)
   public void testBuildComplexObjectInstance() throws ModelSearchException {
     ModelObject testObj = new ModelObject("TestService", "article", null, false);
     JSONObject model = testObj.getModel();


### PR DESCRIPTION
# Adds a new constructor to ModelObject allowing the use of schema content with preset nodes and nodes to build.

## Description

As requested in the issue, there should be a constructor allowing prefetched schemas.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#52

## Motivation and Context

Discussed in the issue.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
As I've not found tests for the others constructors involving a resource location, i have not figured out a way to test this overload. Any tips on this?

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
