### PR TITLE
Full Fuzzing of Arbitrary Schema, Fuzzing optimizations, Model path mapping, Fuzz Report fix

### DIFF
--- a/build/pom.xml
+++ b/build/pom.xml
@@ -70,13 +70,13 @@
     <repository>
       <id>maven2-repository.java.net</id>
       <name>Java.net Repository for Maven</name>
-      <url>http://download.java.net/maven/2/</url>
+      <url>https://download.java.net/maven/2/</url>
       <layout>default</layout>
     </repository>
     <repository>
       <id>central</id>
       <name>Central Repository</name>
-      <url>http://repo.maven.apache.org/maven2</url>
+      <url>https://repo.maven.apache.org/maven2</url>
       <layout>default</layout>
       <snapshots>
         <enabled>false</enabled>
@@ -92,7 +92,7 @@
     <dependency>
       <groupId>org.testng</groupId>
       <artifactId>testng</artifactId>
-      <version>6.11</version>
+      <version>6.8</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/build/pom.xml
+++ b/build/pom.xml
@@ -92,7 +92,7 @@
     <dependency>
       <groupId>org.testng</groupId>
       <artifactId>testng</artifactId>
-      <version>6.8</version>
+      <version>6.14.3</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/libraries/ride-fuzzer-lib/pom.xml
+++ b/libraries/ride-fuzzer-lib/pom.xml
@@ -20,11 +20,6 @@
       <artifactId>ride-core</artifactId>
       <version>${project.parent.version}</version>
     </dependency>
-    <dependency>
-      <groupId>com.github.everit-org.json-schema</groupId>
-      <artifactId>org.everit.json.schema</artifactId>
-      <version>1.9.2</version>
-    </dependency>
   </dependencies>
   
   <profiles>

--- a/libraries/ride-fuzzer-lib/src/main/java/com/adobe/ride/libraries/fuzzer/MetadataFuzzer.java
+++ b/libraries/ride-fuzzer-lib/src/main/java/com/adobe/ride/libraries/fuzzer/MetadataFuzzer.java
@@ -165,7 +165,6 @@ public class MetadataFuzzer {
     }
 
     this.filters = filters;
-    // propertiesFuzzSet = new Object[properties.keySet().size()][3];
 
     // Prep TestNG dataprovider to make reporting better.
     root = (objectToBeFuzzed.getModelType() == ModelPropertyType.OBJECT) ? File.separator
@@ -219,7 +218,6 @@ public class MetadataFuzzer {
     JSONObject properties = null;
 
     properties = ModelObject.getObjectNodeProperties(currentfuzzObject, currentPathModel);
-    
 
     return new ModelProperties(properties);
   }

--- a/libraries/ride-fuzzer-lib/src/main/java/com/adobe/ride/libraries/fuzzer/engines/MetadataEngine.java
+++ b/libraries/ride-fuzzer-lib/src/main/java/com/adobe/ride/libraries/fuzzer/engines/MetadataEngine.java
@@ -130,6 +130,7 @@ public class MetadataEngine extends CoreEngine {
         requestBuilder, filters);
   }
   
+  @Deprecated
   private void initializeEngine(String serviceName, ModelObject entityObj, String parentPath, String property,
       ModelPropertyType type, Object value, Method requestMethod, String contentType,
       RequestSpecBuilder requestBuilder, Filter... filters) throws ModelSearchException {
@@ -162,7 +163,7 @@ public class MetadataEngine extends CoreEngine {
   }
   
   /**
-   * Optimized contrstructor for better performance.
+   * Constructor for optimized full schema fuzzing
    * @param fuzzObj MetadataFuzzer object which contains the schema and other globals
    * @param fuzzInfo MetadataEngineInfo instance which contains info specific to the target path/property
    * @param filters RestAssured filters

--- a/libraries/ride-fuzzer-lib/src/main/java/com/adobe/ride/libraries/fuzzer/engines/MetadataEngine.java
+++ b/libraries/ride-fuzzer-lib/src/main/java/com/adobe/ride/libraries/fuzzer/engines/MetadataEngine.java
@@ -68,6 +68,8 @@ public class MetadataEngine extends CoreEngine {
   /**
    * Constructor for the class from which all of the fuzz target data is derived.
    * 
+   * @param serviceName name of the target service, which is a mapping to the config folder in
+   *        the project resources
    * @param entityObj ModelObject to be fuzzed
    * @param parentPath String path to the key in the object
    * @param property Key in the metadata to be fuzzed. Passed by the Metadata Fuzzer
@@ -78,7 +80,7 @@ public class MetadataEngine extends CoreEngine {
    *        "application/json;charset=utf-8")
    */
   @Deprecated
-  public MetadataEngine(ModelObject entityObj, String parentPath, String property,
+  public MetadataEngine(String serviceName, ModelObject entityObj, String parentPath, String property,
       ModelPropertyType type, Object value, Method requestMethod, String contentType) throws ModelSearchException {
     super(parentPath, property);
     initializeEngine(serviceName, entityObj, parentPath, property, type, value, requestMethod, contentType,
@@ -88,6 +90,8 @@ public class MetadataEngine extends CoreEngine {
   /**
    * Constructor for the class from which all of the fuzz target data is derived.
    * 
+   * @param serviceName name of the target service, which is a mapping to the config folder in
+   *        the project resources
    * @param entityObj ModelObject to be fuzzed
    * @param parentPath String path to the key in the object
    * @param property Key in the metadata to be fuzzed. Passed by the Metadata Fuzzer
@@ -99,7 +103,7 @@ public class MetadataEngine extends CoreEngine {
    * @param requestBuilder Rest-Assured request builder
    */
   @Deprecated
-  public MetadataEngine(ModelObject entityObj, String parentPath, String property,
+  public MetadataEngine(String serviceName, ModelObject entityObj, String parentPath, String property,
       ModelPropertyType type, Object value, Method requestMethod, String contentType,
       RequestSpecBuilder requestBuilder) throws ModelSearchException {
     super(parentPath, property);
@@ -110,6 +114,8 @@ public class MetadataEngine extends CoreEngine {
   /**
    * Constructor for the class from which all of the fuzz target data is derived.
    * 
+   * @param serviceName name of the target service, which is a mapping to the config folder in
+   *        the project resources
    * @param entityObj ModelObject to be fuzzed
    * @param parentPath String path to the key in the object
    * @param property key in the metadata to be fuzzed. Passed by the MetadataFuzzer
@@ -122,9 +128,9 @@ public class MetadataEngine extends CoreEngine {
    * @param filters RestAssured Filters
    */
   @Deprecated
-  public MetadataEngine(ModelObject entityObj, String parentPath, String property,
+  public MetadataEngine(String serviceName, ModelObject entityObj, String parentPath, String property,
       ModelPropertyType type, Object value, Method requestMethod, String contentType,
-      RequestSpecBuilder requestBuilder, Filter... filters) throws ModelSearchException {
+      RequestSpecBuilder requestBuilder, Filter... filters) {
     super(parentPath, property);
     initializeEngine(serviceName, entityObj, parentPath, property, type, value, requestMethod, contentType,
         requestBuilder, filters);
@@ -133,7 +139,7 @@ public class MetadataEngine extends CoreEngine {
   @Deprecated
   private void initializeEngine(String serviceName, ModelObject entityObj, String parentPath, String property,
       ModelPropertyType type, Object value, Method requestMethod, String contentType,
-      RequestSpecBuilder requestBuilder, Filter... filters) throws ModelSearchException {
+      RequestSpecBuilder requestBuilder, Filter... filters) {
 
     this.serviceName = serviceName;
     this.entity = entityObj;
@@ -153,7 +159,7 @@ public class MetadataEngine extends CoreEngine {
     propertyType = type;
     propertyStartValue = value;
 
-    nodeDefinition = entity.getDefinitionAtModelPath(modelProperties, parentPath+property);//(JSONObject) modelProperties.get(fuzzPropertyKey);
+    nodeDefinition = (JSONObject) modelProperties.get(fuzzProperty);
     this.fuzzPropertyIsMutable = MetadataFuzzer.getNodeMutability(nodeDefinition);
 
     if (model.containsKey("definitions")) {

--- a/libraries/ride-fuzzer-lib/src/main/java/com/adobe/ride/libraries/fuzzer/engines/PathEngine.java
+++ b/libraries/ride-fuzzer-lib/src/main/java/com/adobe/ride/libraries/fuzzer/engines/PathEngine.java
@@ -41,11 +41,14 @@ public class PathEngine extends CoreEngine {
   /**
    * Constructor
    * 
+   * @param serviceName name of the target service, which is a mapping to the config folder in
+   *        the project resources
    * @param reqSpec RequestSpecBuilder to be used in the call to the core controller. Usually these
    *        are control values, not test values
    * @param path string path to be fuzzed
    * @param target string part of the target to be fuzzed
    * @param method http action to be invoked (i.e. POST, GET, etc.)
+   * @param filters RestAssured Filters
    */
   public PathEngine(String serviceName, RequestSpecBuilder reqSpec, String path, String target,
       Method method, Filter... filters) {

--- a/libraries/ride-fuzzer-lib/src/main/java/com/adobe/ride/libraries/fuzzer/exceptions/NullPropertyValueException.java
+++ b/libraries/ride-fuzzer-lib/src/main/java/com/adobe/ride/libraries/fuzzer/exceptions/NullPropertyValueException.java
@@ -1,0 +1,42 @@
+/*-
+Copyright 2018 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+package com.adobe.ride.libraries.fuzzer.exceptions;
+
+import org.json.simple.JSONObject;
+
+public class NullPropertyValueException extends Exception {
+  private JSONObject targetObject;
+
+  /**
+   * 
+   */
+  private static final long serialVersionUID = -4954707057674770277L;
+
+  /**
+   * @param obj JSONObject with unexpected format
+   * @param property not found
+   */
+  public NullPropertyValueException(JSONObject obj, String property) {
+    super("The target property '"+property+"' either does not exist in the target instance or has a null value");
+    this.targetObject = obj;
+  }
+
+  /**
+   * Returns the JSONObject associated with the error.
+   * 
+   * @return object which generated the error.
+   */
+  public JSONObject getTargetObject() {
+    return targetObject;
+  }
+}

--- a/sample/build/pom.xml
+++ b/sample/build/pom.xml
@@ -18,13 +18,13 @@
     <repository>
       <id>maven2-repository.java.net</id>
       <name>Java.net Repository for Maven</name>
-      <url>http://download.java.net/maven/2/</url>
+      <url>https://download.java.net/maven/2/</url>
       <layout>default</layout>
     </repository>
     <repository>
       <id>central</id>
       <name>Central Repository</name>
-      <url>http://repo.maven.apache.org/maven2</url>
+      <url>https://repo.maven.apache.org/maven2</url>
       <layout>default</layout>
       <snapshots>
         <enabled>false</enabled>

--- a/sample/sample-product-group-shared-resources/src/main/resources/schemas/SampleService/array_object.json
+++ b/sample/sample-product-group-shared-resources/src/main/resources/schemas/SampleService/array_object.json
@@ -26,7 +26,7 @@
         "title": "The sourceid schema.",
         "type": "string"
       },
-      "timestamp": { "type": "string", "pattern":"^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z$", "format": "date-time", "description":"last modified time in yyyy-MM-dd'T'HH:mm:ssZ format", "mutable":false, "searchable":true },
+      "timestamp": { "type": "string", "pattern":"^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}.\\d{3}Z$", "format": "date-time", "description":"last modified time in yyyy-MM-dd'T'HH:mm:ssZ format", "mutable":false, "searchable":true },
       "xid": {
         "default": "string",
         "description": "An explanation about the purpose of this instance.",

--- a/sample/sample-product-group-shared-resources/src/main/resources/schemas/SampleService/profile.json
+++ b/sample/sample-product-group-shared-resources/src/main/resources/schemas/SampleService/profile.json
@@ -86,7 +86,7 @@
 			"properties": {
 				"createdOn": {
 					"type": "string",
-					"pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z$",
+					"pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}.\\d{3}Z$",
 					"format": "date-time",
 					"description": "creation time in yyyy-MM-dd'T'HH:mm:ssZ format",
 					"mutable": false,
@@ -94,7 +94,7 @@
 				},
 				"modifiedOn": {
 					"type": "string",
-					"pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z$",
+					"pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}.\\d{3}Z$",
 					"format": "date-time",
 					"description": "modification time in yyyy-MM-dd'T'HH:mm:ssZ format",
 					"mutable": false,

--- a/sample/sample-service-extension/src/main/java/com/adobe/ride/sample/cloud_objects/ProfileObject.java
+++ b/sample/sample-service-extension/src/main/java/com/adobe/ride/sample/cloud_objects/ProfileObject.java
@@ -30,7 +30,7 @@ public class ProfileObject extends ModelObject {
   public ProfileObject(String objectName, boolean initRequiredOnly) {
     super(Service.SAMPLE_SERVICE.toString(), CloudObjectType.PROFILE_OBJECT.toString(), objectName,
         initRequiredOnly);
-    buildValidModelInstance();
+    //buildValidModelInstance();
   }
 
   public JSONObject getRemoteProperties() {

--- a/sample/sample-service-server/src/main/java/com/adobe/ride/sample/SampleService.java
+++ b/sample/sample-service-server/src/main/java/com/adobe/ride/sample/SampleService.java
@@ -110,7 +110,7 @@ public class SampleService {
 
     } catch (ValidationException e) {
       responseCode = 400;
-      failureMsgs.add(e.getMessage());
+      failureMsgs.add(e.getAllMessages());
     }
 
     if (responseCode == 400) {

--- a/sample/sample-service-server/src/main/java/com/adobe/ride/sample/SampleService.java
+++ b/sample/sample-service-server/src/main/java/com/adobe/ride/sample/SampleService.java
@@ -232,9 +232,9 @@ public class SampleService {
       writer.close();
       writeSuccess = true;
     } catch (UnsupportedEncodingException | FileNotFoundException e) {
-      e.printStackTrace();
+      System.out.println("DB write failed");
     } catch (IOException e) {
-      e.printStackTrace();
+      System.out.println("DB write failed");
     }
     return writeSuccess;
   }
@@ -260,7 +260,7 @@ public class SampleService {
       statement.setQueryTimeout(30); // set timeout to 30 sec.
       statement.executeUpdate(query);
     } catch (SQLException e) {
-      e.printStackTrace();
+      System.out.println("Failed POST Query: "+query);
     }
   }
 
@@ -271,7 +271,7 @@ public class SampleService {
       statement.setQueryTimeout(30); // set timeout to 30 sec.
       result = statement.executeQuery(query);
     } catch (SQLException e) {
-      e.printStackTrace();
+      System.out.println("Failed GET Query: "+query);
     }
 
     return result;

--- a/sample/sample-service-tests/src/test/java/com/adobe/ride/sample/BasicTest_IT.java
+++ b/sample/sample-service-tests/src/test/java/com/adobe/ride/sample/BasicTest_IT.java
@@ -90,6 +90,7 @@ public class BasicTest_IT {
     String itemName = UUID.randomUUID().toString();
     // Create Object
     ProfileObject testObject = new ProfileObject(itemName, false);
+    testObject.buildValidModelInstance();
     // Send Object To Server
     SampleServiceController.createOrUpdateArrayObject(testObject.getObjectPath(), testObject,
         ExpectedResponse.CREATED_RESPONSE, false);

--- a/sample/sample-service-tests/src/test/java/com/adobe/ride/sample/Complex_Fuzz_Test_IT.java
+++ b/sample/sample-service-tests/src/test/java/com/adobe/ride/sample/Complex_Fuzz_Test_IT.java
@@ -1,0 +1,36 @@
+/*-
+Copyright 2018 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+package com.adobe.ride.sample;
+
+import java.util.UUID;
+
+import org.testng.annotations.Factory;
+import com.adobe.ride.libraries.fuzzer.MetadataFuzzer;
+// import com.adobe.ride.sample.cloud_objects.SampleServiceObject1;
+import com.adobe.ride.sample.cloud_objects.ProfileObject;
+import com.adobe.ride.sample.types.Service;
+
+/**
+ * 
+ * @author tedcasey
+ *
+ */
+public class Complex_Fuzz_Test_IT {
+
+  @Factory
+  public Object[] fuzzObjectMetadata_IT() throws Exception {
+    String itemName = UUID.randomUUID().toString();
+    ProfileObject object1 = new ProfileObject(itemName, false);
+    return new Object[] {new MetadataFuzzer(Service.SAMPLE_SERVICE.toString(), object1)};
+  }
+}

--- a/utilities/ride-model-util/pom.xml
+++ b/utilities/ride-model-util/pom.xml
@@ -35,6 +35,11 @@
       <artifactId>commons-codec</artifactId>
       <version>1.10</version>
     </dependency>
+    <dependency>
+      <groupId>com.github.everit-org.json-schema</groupId>
+	    <artifactId>org.everit.json.schema</artifactId>
+	    <version>1.12.1</version>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/utilities/ride-model-util/pom.xml
+++ b/utilities/ride-model-util/pom.xml
@@ -35,11 +35,6 @@
       <artifactId>commons-codec</artifactId>
       <version>1.10</version>
     </dependency>
-    <dependency>
-      <groupId>com.github.everit-org.json-schema</groupId>
-	    <artifactId>org.everit.json.schema</artifactId>
-	    <version>1.12.1</version>
-    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/utilities/ride-model-util/src/main/java/com/adobe/ride/utilities/model/ModelObject.java
+++ b/utilities/ride-model-util/src/main/java/com/adobe/ride/utilities/model/ModelObject.java
@@ -25,9 +25,11 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.Validate;
+/*
 import org.everit.json.schema.Schema;
 import org.everit.json.schema.ValidationException;
 import org.everit.json.schema.loader.SchemaLoader;
+*/
 import org.joda.time.DateTime;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
@@ -44,7 +46,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.fasterxml.jackson.databind.util.RawValue;
 import com.fasterxml.jackson.databind.node.MissingNode;
 
 /**

--- a/utilities/ride-model-util/src/main/java/com/adobe/ride/utilities/model/ModelObject.java
+++ b/utilities/ride-model-util/src/main/java/com/adobe/ride/utilities/model/ModelObject.java
@@ -25,6 +25,9 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.Validate;
+import org.everit.json.schema.Schema;
+import org.everit.json.schema.ValidationException;
+import org.everit.json.schema.loader.SchemaLoader;
 import org.joda.time.DateTime;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
@@ -69,7 +72,7 @@ public class ModelObject {
   protected boolean requiredOnly = false;
   protected String modelString;
   private final String NULL_MODEL_VALUE = "nulledValue";
-  private static final String REFERENCE_KEY = "$ref";
+  public static final String REFERENCE_KEY = "$ref";
   private String serviceName;
   private String objectPath;
   private String objectName;
@@ -79,6 +82,9 @@ public class ModelObject {
   protected JSONArray objectItems;
   protected JSONObject presetNodes;
   protected Set<String> nodesToBuild;
+  //private Schema schema;
+  private Object metadata;
+
 
   public ModelObject() {
 
@@ -94,28 +100,43 @@ public class ModelObject {
       // turn model contents into usable JSONObjects
       model = (JSONObject) parser.parse(modelString);
       modelType = ModelPropertyType.eval(model.get("type").toString());
+
       if (modelType == ModelPropertyType.OBJECT) {
         modelProperties = (JSONObject) model.get("properties");
         requiredModelProperties = (JSONArray) model.get("required");
         modelDefinitions = (JSONObject) model.get("definitions");
-        try {
-          modelPropertiesNodes = mapper.readTree(modelProperties.toJSONString());
-        } catch (IOException e) {
-          logger.log(Level.SEVERE, "An error was thrown while deserializing the JSON content", e);
-        }
+        
       } else if (modelType == ModelPropertyType.ARRAY) {
         JSONObject arrayDef = ((JSONObject) model.get("items"));
-        modelProperties = ((JSONObject) arrayDef.get("properties"));
+        modelProperties = getModelProperties(this, arrayDef);
         requiredModelProperties = (JSONArray) arrayDef.get("required");
         modelDefinitions = (JSONObject) model.get("definitions");
-        try {
-          modelPropertiesNodes = mapper.readTree(modelProperties.toJSONString());
-        } catch (IOException e) {
-          logger.log(Level.SEVERE, "An error was thrown while deserializing the JSON content", e);
-        }
       }
+      
+      try {
+        String loadableProperties = (modelProperties != null)?modelProperties.toJSONString():modelString;
+        modelPropertiesNodes = mapper.readTree(loadableProperties);
+      } catch (IOException e) {
+        logger.log(Level.SEVERE, "An error was thrown while deserializing the JSON content", e);
+      }
+
+      //org.json.JSONObject rawSchema = new org.json.JSONObject(getModelString());
+      //schema = SchemaLoader.load(rawSchema);
+      
     } catch (ParseException e) {
       logger.log(Level.SEVERE, "A Parse exception was thrown", e);
+    }
+  }
+  
+  public JSONObject getDefinitionAtModelPath(JSONObject nodeDef, String path) {
+    String[] pathParts = path.split("/", 2);
+    
+    JSONObject parentDef = ((JSONObject) nodeDef.get(pathParts[1]));
+    
+    if(!((pathParts[1]).contains("/"))) {
+      return parentDef;
+    } else {
+      return getDefinitionAtModelPath(getModelProperties(this, parentDef), pathParts[1]);
     }
   }
 
@@ -279,14 +300,14 @@ public class ModelObject {
   }
 
   /**
-	 * Static constructor to initialize with a JSON schema string. Optional parameters for
-	 * adding preset nodes, defining target nodes, and whether to use only required
-	 * nodes.
+   * Static constructor to initialize with a JSON schema string. Optional parameters for adding
+   * preset nodes, defining target nodes, and whether to use only required nodes.
+   * 
    * @param modelString string which conforms to JSON schema standards
    * @param presetNodes optional set of JSON nodes and values to be used in the object, not
    *        generated dynamically
-   * @param nodesToBuild optional set of JSONnodes which are to be dynamically generated.
-   *        Remaining schema defined nodes will not be generated.
+   * @param nodesToBuild optional set of JSONnodes which are to be dynamically generated. Remaining
+   *        schema defined nodes will not be generated.
    * @param useRequiredOnly boolean to determine whether to build only the required json nodes as
    *        defined in the spec
    *
@@ -328,6 +349,14 @@ public class ModelObject {
   public JSONObject getModel() {
     return model;
   }
+  
+  /**
+   * 
+   * @return ModelPropertyType Object Type
+   */
+  public ModelPropertyType getModelType() {
+    return modelType;
+  }
 
   /**
    * 
@@ -336,6 +365,59 @@ public class ModelObject {
   public JSONObject getModelProperties() {
     return modelProperties;
   }
+
+
+  /**
+   * Method which retrieves the property definition for
+   * 
+   * @param propertyModel model of the object node
+   * @return JSONObject properties of the model
+   */
+  private JSONObject getObjectNodeProperties(JSONObject propertyModel) {
+    JSONObject properties = new JSONObject();
+    if (propertyModel.containsKey("patternProperties")) {
+      properties = (JSONObject) propertyModel.get("patternProperties");
+    } else if (propertyModel.containsKey("properties")) {
+      properties = (JSONObject) propertyModel.get("properties");
+    } else if (propertyModel.containsKey("items")) {
+      JSONObject items = (JSONObject) propertyModel.get("items");
+      properties = (JSONObject) getModelProperties(this, items);
+    } else {
+      try {
+        throw new UnexpectedModelDefinitionException(propertyModel);
+      } catch (UnexpectedModelDefinitionException e) {
+        logger.log(Level.SEVERE, e.getMessage());
+      }
+    }
+
+    return properties;
+  }
+
+  
+  public static JSONObject getModelProperties(ModelObject model, JSONObject propertyDef) {
+    JSONObject properties = null;
+    ModelPropertyType type;
+    try {
+      type = getModelPropertyType(propertyDef);
+      if (type == ModelPropertyType.OBJECT || type == ModelPropertyType.ARRAY) {
+        properties = model.getObjectNodeProperties(propertyDef);
+      } else if (type == ModelPropertyType.REF_SCHEMA) {
+        String objectString = propertyDef.get(REFERENCE_KEY).toString();
+        String relativeSchema;
+        relativeSchema = getRelativeResourceLocation(model.resourceLocation, objectString);
+        ModelObject newObj = new ModelObject(relativeSchema);
+        properties = newObj.modelProperties;
+      } else if (type == ModelPropertyType.REF_DEFINITION) {
+        JSONObject definition = model.getDefinitionRef(propertyDef);
+        properties = model.getObjectNodeProperties(definition);
+      }
+    } catch (UnexpectedModelPropertyTypeException e) {
+      // TODO Auto-generated catch block
+      e.printStackTrace();
+    }
+    return properties;
+  }
+
 
   /**
    * 
@@ -534,6 +616,7 @@ public class ModelObject {
    * @return Object JSON Object of model type
    */
   public Object buildValidModelInstance() {
+    Object returnObject = null;
     if (modelType == ModelPropertyType.OBJECT) {
       if (presetNodes != null && objectMetadata.isEmpty()) {
         objectMetadata = presetNodes;
@@ -543,22 +626,47 @@ public class ModelObject {
         return buildTargetedNodes();
       } else {
         JSONObject modelSet = (requiredOnly) ? getRequiredOnlyDefs(model) : modelProperties;
-        return buildModelInstance(modelSet);
+        returnObject = buildModelInstance(modelSet);
       }
     } else if (modelType == ModelPropertyType.ARRAY) {
       try {
         ArrayNode generatedItems = buildArrayNode(model);
         String itemsString = generatedItems.toString();
         objectItems = (JSONArray) (parser.parse(itemsString));
+        returnObject = objectItems;
       } catch (ParseException e) {
         logger.log(Level.SEVERE, e.getMessage());
       }
       return objectItems;
     } else {
       // Handling Primitive type schemas
-      return generateNodeValue(model);
+      returnObject = generateNodeValue(model);
+    }
+    setMetadata();
+    return returnObject;
+  }
+  
+  /*
+  public boolean validateMetadata() {
+    boolean validationValue = true;
+    try {
+      schema.validate(metadata);
+    } catch (ValidationException e) {
+      validationValue = false;
+    }
+    return validationValue;
+  }
+  */
+  
+  private void setMetadata() {
+    ModelPropertyType type = getModelType();
+    if(type.equals(ModelPropertyType.OBJECT)) {
+      metadata = objectMetadata;
+    } else {
+      metadata = objectItems;
     }
   }
+
 
   private Object buildTargetedNodes() {
     for (String str : nodesToBuild) {
@@ -843,6 +951,7 @@ public class ModelObject {
 
     return returnObj;
   }
+  
 
   @SuppressWarnings("unchecked")
   private ArrayNode buildArrayNode(JSONObject propertyDef) {
@@ -1413,7 +1522,7 @@ public class ModelObject {
       }
 
       if (parentPath != null) {// not dealing with root so don't add value
-        setMetadataValue(type, parentPath, key, returnValue);
+        setMetadataValue(parentPath, key, returnValue);
       }
 
       return returnValue;
@@ -1427,7 +1536,7 @@ public class ModelObject {
    * @param relativePath relative path to referenced schema
    * @return String
    */
-  protected String getRelativeResourceLocation(String controlPath, String relativePath) {
+  protected static String getRelativeResourceLocation(String controlPath, String relativePath) {
     String returnPath = "";
     String[] relativeSegments = relativePath.split("\\.\\.");
     int relSegLength = relativeSegments.length;
@@ -1457,53 +1566,98 @@ public class ModelObject {
   private void refreshMetadata(JsonNode dataTree) {
     try {
       String treeString = mapper.writeValueAsString(dataTree);
-      objectMetadata = (JSONObject) parser.parse(treeString);
+      if(modelType.equals(ModelPropertyType.OBJECT)) {
+        objectMetadata = (JSONObject) parser.parse(treeString);
+      } else {
+        objectItems = (JSONArray) parser.parse(treeString);
+      }
     } catch (ParseException | JsonProcessingException e) {
       logger.log(Level.SEVERE, e.getMessage());
     }
+  }
+  
+  public Object getMetadata() {
+    return (modelType.equals(ModelPropertyType.OBJECT))?objectMetadata:objectItems;
+  }
+  
+  public String getMetadataString() {
+    return (modelType.equals(ModelPropertyType.OBJECT))?objectMetadata.toJSONString():objectItems.toJSONString();
+  }
+  
+  public Object getMetadataValue(String path, String key) {
+    Object exisitingValue = null;
+    if (path == null || path == null + "/" + null) {
+      exisitingValue = null;
+    } else {
+      try {
+        String jsonstring = "";
+
+        if(getModelType() == ModelPropertyType.OBJECT) {
+          jsonstring = objectMetadata.toJSONString();
+        } else if (getModelType() == ModelPropertyType.ARRAY) {
+          jsonstring = objectItems.toJSONString();
+        }
+        
+        //look up value (strip trailing slash from parent path)
+        Object value = mapper.readTree(jsonstring).at(path.replaceAll("/$", "")).get(key);
+
+        if (value != null) {
+          exisitingValue = (Object) value;
+        } else {
+          exisitingValue = null;
+        }
+      } catch (Exception e) {
+        logger.log(Level.SEVERE, e.getMessage());
+      }
+    }
+    return exisitingValue;
   }
 
   /**
    * Method to cast and post value to json node path.
    * 
-   * @param type ModelPropertyType
-   * @param pathToParent String Fully qualified path to parent node of the target
-   * @param key String target node
+   * @param metadataPath String Fully qualified path to parent node of the target
+   * @param key String target node key
    * @param value Object value to be assigned
    */
-  protected void setMetadataValue(ModelPropertyType type, String pathToParent, String key,
+  public void setMetadataValue(String metadataPath, String key,
       Object value) {
     JsonNode tree = null;
-    pathToParent = (pathToParent == "/") ? "" : pathToParent;
+    
     try {
 
-      tree = mapper.readTree(objectMetadata.toJSONString());
+      tree = mapper.readTree(getMetadataString());
     } catch (IOException e) {
       logger.log(Level.SEVERE, e.getMessage());
     }
-    if (type == ModelPropertyType.BOOLEAN) {
-      ((ObjectNode) tree.at(pathToParent)).put(key, Boolean.parseBoolean(value.toString()));
-    } else if (type == ModelPropertyType.INTEGER) {
-      ((ObjectNode) tree.at(pathToParent)).put(key, Long.parseLong(value.toString()));
-    } else if (type == ModelPropertyType.NUMBER) {
-      ((ObjectNode) tree.at(pathToParent)).put(key, Double.parseDouble(value.toString()));
-    } else if (type == ModelPropertyType.OBJECT || type == ModelPropertyType.REF_DEFINITION
-        || type == ModelPropertyType.REF_SCHEMA || type == ModelPropertyType.ARRAY) {
+    
+    String path = metadataPath.replaceAll("/$", "");
+    
+    String stringRep = value.toString();
+    if (isBoolean(value)) {
+      ((ObjectNode) tree.at(path)).put(key, Boolean.parseBoolean(stringRep));
+    } else if (isInt(value)) {
+      ((ObjectNode) tree.at(path)).put(key, Long.parseLong(stringRep));
+    } else if (isNumber(value)) {
+      ((ObjectNode) tree.at(path)).put(key, Double.parseDouble(stringRep));
+    }  else if(isArrayNode(value)) {
+      ((ObjectNode) tree.at(path)).putArray(key).addAll((ArrayNode) value);
+    } else if (isObject(value)) {
       try {
-        String stringValue = value.toString();
-        JsonNode node = mapper.readTree(stringValue);
-        ((ObjectNode) tree.at(pathToParent)).set(key, node);
+        JsonNode node = mapper.readTree(stringRep);
+        ((ObjectNode) tree.at(path)).set(key, node);
       } catch (IOException e) {
         logger.log(Level.SEVERE, e.getMessage());
       }
-    } else if (type == ModelPropertyType.NULL) {
-      ((ObjectNode) tree.at(pathToParent)).putNull(key);
+    } else if (value == null || value == "null") {
+      ((ObjectNode) tree.at(path)).putNull(key);
     } else {
-
-      ((ObjectNode) tree.at(pathToParent)).put(key, value.toString());
+      JsonNode node = tree.at(path);
+      ((ObjectNode) node).put(key, stringRep);
     }
     refreshMetadata(tree);
   }
+
 
   /**
    * Returns path to the Object.
@@ -1566,6 +1720,7 @@ public class ModelObject {
    * @param data data to be set
    */
   @SuppressWarnings("unchecked")
+  @Deprecated
   public void setDataAtItemsIndex(int index, JSONObject data) {
     if (modelType == ModelPropertyType.ARRAY) {
       objectItems.set(index, data);
@@ -1581,6 +1736,7 @@ public class ModelObject {
    * @param index position of the item
    * @return JSONObject
    */
+  @Deprecated
   public JSONObject getDataAtItemsIndex(int index) {
     if (modelType == ModelPropertyType.ARRAY) {
       return (JSONObject) objectItems.get(index);
@@ -1620,6 +1776,46 @@ public class ModelObject {
   public String getObjectType() {
     return objectType;
   }
+  
+  private boolean isBoolean(Object value) {
+    if( value.toString().equalsIgnoreCase("true") || value.toString().equalsIgnoreCase("false")){
+      return true;
+    } else {
+      return false;
+    }
+  }
+  
+  private boolean isInt(Object value) {
+    if(value instanceof Long){
+      return true;
+    } else {
+      return false;
+    }
+  }
+  
+  private boolean isNumber(Object value) {
+    if(value instanceof Double){
+      return true;
+    } else {
+      return false;
+    }
+  }
+  
+  private boolean isObject(Object value) {
+    if(value instanceof JSONObject){
+      return true;
+    } else {
+      return false;
+    }
+  }
+  
+  private boolean isArrayNode(Object value) {
+    if(value instanceof ArrayNode){
+      return true;
+    } else {
+      return false;
+    }
+  }
 
   /**
    * Returns location of the schema in the project resources.
@@ -1637,6 +1833,7 @@ public class ModelObject {
    * @param value new value of the key
    */
   @SuppressWarnings("unchecked")
+  @Deprecated
   public void setObjectMetadataProperty(String property, Object value) {
     if (objectMetadata.containsKey(property)) {
       objectMetadata.remove(property);
@@ -1650,6 +1847,7 @@ public class ModelObject {
    * @param property string representation of the property to be retrieved
    * @return Object representation of the value
    */
+  @Deprecated
   public Object getObjectMetadataProperty(String property) {
     return objectMetadata.get(property);
   }
@@ -1660,6 +1858,7 @@ public class ModelObject {
    * @param path standard path to the node in the object instance to be retrieved
    * @return Object
    */
+  @Deprecated
   public Object getObjectMetadataValueAt(String path) {
     JsonNode node = null;
     try {
@@ -1678,6 +1877,7 @@ public class ModelObject {
    * @param property String representation of the property to be removed
    * @return boolean indicator of whether the property existed previously
    */
+  @Deprecated
   public boolean removeObjectMetadataProperty(String property) {
     boolean existed = false;
     if (objectMetadata.containsKey(property)) {

--- a/utilities/ride-model-util/src/main/java/com/adobe/ride/utilities/model/ModelObject.java
+++ b/utilities/ride-model-util/src/main/java/com/adobe/ride/utilities/model/ModelObject.java
@@ -135,7 +135,7 @@ public class ModelObject {
    * Method to retrieve the property definition of a key within a schema, based on a fully qualified path
    * @param parentNodeDef Node which contains the root of the path
    * @param path qualified path mapping to hierachrical nodes within a schema
-   * @return a JSOBObject representation of the target definition
+   * @return a JSONObject representation of the target definition
    * @throws ModelSearchException
    */
   public JSONObject getDefinitionAtModelPath(JSONObject parentNodeDef, String path)
@@ -192,12 +192,6 @@ public class ModelObject {
       throw new ModelSearchException(parentNodeDef, path);
     }
   }
-
-  /*
-   * private JSONObject returnMappedObject(JSONObject nodeDef, String[] pathParts) {
-   * 
-   * }
-   */
 
   /**
    * Method to load the model from a file in the resourceLocation which is expected to be
@@ -427,7 +421,7 @@ public class ModelObject {
 
 
   /**
-   * Method which retrieves the property definition for
+   * Method which retrieves the property definition for the various JSON object types
    * 
    * @param propertyModel model of the object node
    * @return JSONObject properties of the model
@@ -476,7 +470,6 @@ public class ModelObject {
         properties = model.getObjectNodeProperties(definition);
       }
     } catch (UnexpectedModelPropertyTypeException e) {
-      // TODO Auto-generated catch block
       e.printStackTrace();
     }
     return properties;

--- a/utilities/ride-model-util/src/test/java/com/adobe/ride/utilities/model/test/ModelObjectTest.java
+++ b/utilities/ride-model-util/src/test/java/com/adobe/ride/utilities/model/test/ModelObjectTest.java
@@ -50,7 +50,7 @@ public class ModelObjectTest {
     testObj.buildValidModelInstance();
     ModelObject.prettyPrintToConsole(testObj.getObjectMetadata());
     Set<String> test = testObj.getObjectMetadata().keySet();
-    Set<String> control = testObj.getModelProperties().keySet();
+    Set<String> control = ModelObject.getModelProperties(testObj, testObj.getModel()).keySet();
     Assert.assertTrue(test.containsAll(control));
   }
 
@@ -64,7 +64,7 @@ public class ModelObjectTest {
     ModelObject.prettyPrintToConsole(items);
     JSONArray objectItems = testArray.getObjectItems();
     Set<String> element1 = ((JSONObject) objectItems.get(0)).keySet();
-    Set<String> control = testArray.getModelProperties().keySet();
+    Set<String> control = ModelObject.getModelProperties(testArray, testArray.getModel()).keySet();
     Assert.assertTrue(element1.containsAll(control));
   }
 
@@ -77,7 +77,7 @@ public class ModelObjectTest {
     responseObj.buildValidModelInstance();
     ModelObject.prettyPrintToConsole(responseObj.getObjectMetadata());
     Set<String> test = responseObj.getObjectMetadata().keySet();
-    Set<String> control = responseObj.getModelProperties().keySet();
+    Set<String> control = ModelObject.getModelProperties(responseObj, responseObj.getModel()).keySet();
     Assert.assertTrue(test.containsAll(control));
   }
 
@@ -102,7 +102,7 @@ public class ModelObjectTest {
     responseObj.buildValidModelInstance();
     ModelObject.prettyPrintToConsole(responseObj.getObjectMetadata());
     Set<String> test = responseObj.getObjectMetadata().keySet();
-    Set<String> control = responseObj.getModelProperties().keySet();
+    Set<String> control = ModelObject.getModelProperties(responseObj, responseObj.getModel()).keySet();
     Assert.assertTrue(test.containsAll(control));
   }
 
@@ -157,7 +157,7 @@ public class ModelObjectTest {
     testObj.buildValidModelInstance();
     ModelObject.prettyPrintToConsole(testObj.getObjectMetadata());
     Set<String> test = testObj.getObjectMetadata().keySet();
-    Set<String> control = testObj.getModelProperties().keySet();
+    Set<String> control = ModelObject.getModelProperties(testObj, testObj.getModel()).keySet();
     Assert.assertTrue(test.containsAll(control));
   }
 
@@ -175,7 +175,7 @@ public class ModelObjectTest {
     testObj.buildValidModelInstance();
     ModelObject.prettyPrintToConsole(testObj.getObjectMetadata());
     Set<String> test = testObj.getObjectMetadata().keySet();
-    Set<String> control = testObj.getModelProperties().keySet();
+    Set<String> control = ModelObject.getModelProperties(testObj, testObj.getModel()).keySet();
     Assert.assertTrue(test.containsAll(control));
   }
 
@@ -191,7 +191,7 @@ public class ModelObjectTest {
     JSONObject newObject = (JSONObject) testObj.buildNewModelInstance();
     ModelObject.prettyPrintToConsole(newObject);
     Set<String> test = newObject.keySet();
-    Set<String> control = testObj.getModelProperties().keySet();
+    Set<String> control = ModelObject.getModelProperties(testObj, testObj.getModel()).keySet();
     Assert.assertTrue(test.containsAll(control));
   }
 
@@ -210,7 +210,7 @@ public class ModelObjectTest {
     testObj.buildValidModelInstance();
     ModelObject.prettyPrintToConsole(testObj.getObjectMetadata());
     Set<String> test = testObj.getObjectMetadata().keySet();
-    Set<String> control = testObj.getModelProperties().keySet();
+    Set<String> control = ModelObject.getModelProperties(testObj, testObj.getModel()).keySet();
     Assert.assertTrue(test.containsAll(control));
   }
 

--- a/utilities/ride-model-util/src/test/java/com/adobe/ride/utilities/model/test/ModelObjectTest.java
+++ b/utilities/ride-model-util/src/test/java/com/adobe/ride/utilities/model/test/ModelObjectTest.java
@@ -50,7 +50,7 @@ public class ModelObjectTest {
     testObj.buildValidModelInstance();
     ModelObject.prettyPrintToConsole(testObj.getObjectMetadata());
     Set<String> test = testObj.getObjectMetadata().keySet();
-    Set<String> control = ModelObject.getModelProperties(testObj, testObj.getModel()).keySet();
+    Set<String> control = ModelObject.getObjectNodeProperties(testObj, testObj.getModel()).keySet();
     Assert.assertTrue(test.containsAll(control));
   }
 
@@ -64,7 +64,7 @@ public class ModelObjectTest {
     ModelObject.prettyPrintToConsole(items);
     JSONArray objectItems = testArray.getObjectItems();
     Set<String> element1 = ((JSONObject) objectItems.get(0)).keySet();
-    Set<String> control = ModelObject.getModelProperties(testArray, testArray.getModel()).keySet();
+    Set<String> control = ModelObject.getObjectNodeProperties(testArray, testArray.getModel()).keySet();
     Assert.assertTrue(element1.containsAll(control));
   }
 
@@ -77,7 +77,7 @@ public class ModelObjectTest {
     responseObj.buildValidModelInstance();
     ModelObject.prettyPrintToConsole(responseObj.getObjectMetadata());
     Set<String> test = responseObj.getObjectMetadata().keySet();
-    Set<String> control = ModelObject.getModelProperties(responseObj, responseObj.getModel()).keySet();
+    Set<String> control = ModelObject.getObjectNodeProperties(responseObj, responseObj.getModel()).keySet();
     Assert.assertTrue(test.containsAll(control));
   }
 
@@ -102,7 +102,7 @@ public class ModelObjectTest {
     responseObj.buildValidModelInstance();
     ModelObject.prettyPrintToConsole(responseObj.getObjectMetadata());
     Set<String> test = responseObj.getObjectMetadata().keySet();
-    Set<String> control = ModelObject.getModelProperties(responseObj, responseObj.getModel()).keySet();
+    Set<String> control = ModelObject.getObjectNodeProperties(responseObj, responseObj.getModel()).keySet();
     Assert.assertTrue(test.containsAll(control));
   }
 
@@ -157,7 +157,7 @@ public class ModelObjectTest {
     testObj.buildValidModelInstance();
     ModelObject.prettyPrintToConsole(testObj.getObjectMetadata());
     Set<String> test = testObj.getObjectMetadata().keySet();
-    Set<String> control = ModelObject.getModelProperties(testObj, testObj.getModel()).keySet();
+    Set<String> control = ModelObject.getObjectNodeProperties(testObj, testObj.getModel()).keySet();
     Assert.assertTrue(test.containsAll(control));
   }
 
@@ -175,7 +175,7 @@ public class ModelObjectTest {
     testObj.buildValidModelInstance();
     ModelObject.prettyPrintToConsole(testObj.getObjectMetadata());
     Set<String> test = testObj.getObjectMetadata().keySet();
-    Set<String> control = ModelObject.getModelProperties(testObj, testObj.getModel()).keySet();
+    Set<String> control = ModelObject.getObjectNodeProperties(testObj, testObj.getModel()).keySet();
     Assert.assertTrue(test.containsAll(control));
   }
 
@@ -191,7 +191,7 @@ public class ModelObjectTest {
     JSONObject newObject = (JSONObject) testObj.buildNewModelInstance();
     ModelObject.prettyPrintToConsole(newObject);
     Set<String> test = newObject.keySet();
-    Set<String> control = ModelObject.getModelProperties(testObj, testObj.getModel()).keySet();
+    Set<String> control = ModelObject.getObjectNodeProperties(testObj, testObj.getModel()).keySet();
     Assert.assertTrue(test.containsAll(control));
   }
 
@@ -210,7 +210,7 @@ public class ModelObjectTest {
     testObj.buildValidModelInstance();
     ModelObject.prettyPrintToConsole(testObj.getObjectMetadata());
     Set<String> test = testObj.getObjectMetadata().keySet();
-    Set<String> control = ModelObject.getModelProperties(testObj, testObj.getModel()).keySet();
+    Set<String> control = ModelObject.getObjectNodeProperties(testObj, testObj.getModel()).keySet();
     Assert.assertTrue(test.containsAll(control));
   }
 

--- a/utilities/ride-model-util/src/test/resources/schemas/TestService/article.json
+++ b/utilities/ride-model-util/src/test/resources/schemas/TestService/article.json
@@ -47,7 +47,7 @@
 					"thumbnail": { "$ref":"#/definitions/imagelink", "imagelink":true },
 					"socialSharing": { "$ref":"#/definitions/imagelink", "imagelink":true },
 					"collections" : { "type" : "array", "items": { "$ref":"entitylink.json" }, "mutable":false },
-					"relatedContent" : { "type" : "array", "items": { "$ref":"./entitylink.json" } },
+					"relatedContent" : { "type" : "array", "items": { "$ref":"entitylink.json" } },
 					"articleFolio" : {  "$ref":"#/definitions/contentlink"  }
 					}
 			},


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

List of changes:

- Full deep fuzzing of arbitrary schema
- Model Path mapping
- Schema node definition search by path
- Fix to Fuzzer reporting (in Eclipse)
- Performance optimizations to Fuzzer
- Removal of Everit (due to lack of relative schema file ref support).


*** BREAKING CHANGE TO THE FUZZER ***
This change requires a breaking change to the fuzzer.  This is an unfortunate side-effect, but changes required to existing code utilizing the fuzzer are most likely minimal, if any at all, and worth the trade off in functionality.  The breaking changes were in the MetadataEngine constructors which are most likely not used outside of the MetadataFuzzer, and not called directly.

<!--- Describe your changes in detail -->

## Related Issue

https://github.com/adobe/ride/issues/59

## Motivation and Context

Better fuzzing

## How Has This Been Tested?

Unit tests and sample tests all pass.
Added sample test for complex schema fuzzing.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
